### PR TITLE
Displaying data visually for traders

### DIFF
--- a/src/DataManipulator.ts
+++ b/src/DataManipulator.ts
@@ -1,20 +1,42 @@
 import { ServerRespond } from './DataStreamer';
 
 export interface Row {
-  stock: string,
-  top_ask_price: number,
-  timestamp: Date,
+  price_abc : number,
+  price_def : number,
+  ratio : number,
+  timestamp : Date,
+  upper_bound : number,
+  lower_bound : number,
+  trigger_alert : number | undefined,
 }
 
 
 export class DataManipulator {
-  static generateRow(serverResponds: ServerRespond[]) {
-    return serverResponds.map((el: any) => {
-      return {
-        stock: el.stock,
-        top_ask_price: el.top_ask && el.top_ask.price || 0,
-        timestamp: el.timestamp,
-      };
-    })
+  static generateRow(serverRespond: ServerRespond[]): Row {
+    const priceABC = (serverRespond[0].top_ask.price + serverRespond[0].top_bid.price) / 2;
+    const priceDEF = (serverRespond[1].top_ask.price + serverRespond[1].top_bid.price) / 2;
+    const ratio = priceABC / priceDEF;
+
+    const historicalAverageRatio = this.getHistoricalAverageRatio();
+
+    const upperBound = historicalAverageRatio * 1.1;
+    const lowerBound = historicalAverageRatio * 0.99;
+
+    return {
+      price_abc: priceABC,
+      price_def: priceDEF,
+      ratio,
+      timestamp: serverRespond[0].timestamp > serverRespond[1].timestamp ? 
+                 serverRespond[0].timestamp : serverRespond[1].timestamp,
+      upper_bound: upperBound,
+      lower_bound: lowerBound,
+      trigger_alert: (ratio > upperBound || ratio < lowerBound) ? ratio : undefined,
+    };
+  }
+
+  static getHistoricalAverageRatio(): number {
+    // Implement this method to calculate or retrieve the 12-month historical average ratio
+    // For now, returning a placeholder value
+    return 1.0; // Replace with actual calculation
   }
 }

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Table } from '@finos/perspective';
+import { Table, TableData } from '@finos/perspective';
 import { ServerRespond } from './DataStreamer';
 import { DataManipulator } from './DataManipulator';
 import './Graph.css';
@@ -23,10 +23,13 @@ class Graph extends Component<IProps, {}> {
     const elem = document.getElementsByTagName('perspective-viewer')[0] as unknown as PerspectiveViewerElement;
 
     const schema = {
-      stock: 'string',
-      top_ask_price: 'float',
-      top_bid_price: 'float',
-      timestamp: 'date',
+      price_abc : 'float',
+      price_def : 'float',
+      ratio : 'float',
+      timestamp : 'date',
+      upper_bound : 'float',
+      lower_bound : 'float',
+      trigger_alert : 'float',
     };
 
     if (window.perspective && window.perspective.worker()) {
@@ -36,23 +39,25 @@ class Graph extends Component<IProps, {}> {
       // Load the `table` in the `<perspective-viewer>` DOM reference.
       elem.load(this.table);
       elem.setAttribute('view', 'y_line');
-      elem.setAttribute('column-pivots', '["stock"]');
       elem.setAttribute('row-pivots', '["timestamp"]');
-      elem.setAttribute('columns', '["top_ask_price"]');
+      elem.setAttribute('columns', '["ratio", "lower_bound", "upper_bound", "trigger_alert"]');
       elem.setAttribute('aggregates', JSON.stringify({
-        stock: 'distinctcount',
-        top_ask_price: 'avg',
-        top_bid_price: 'avg',
-        timestamp: 'distinct count',
+        price_abc : 'avg',
+        price_def : 'avg',
+        ratio : 'avg',
+        timestamp : 'distinct count',
+        upper_bound : 'avg',
+        lower_bound : 'avg',
+        trigger_alert : 'avg',
       }));
     }
   }
 
   componentDidUpdate() {
     if (this.table) {
-      this.table.update(
+      this.table.update([
         DataManipulator.generateRow(this.props.data),
-      );
+      ] as unknown as TableData);
     }
   }
 }


### PR DESCRIPTION
This updated graph now tracks the ratio between two stocks over time rather than just the top_ask_price of the two stocks. Additionally, the graph shows the historical correlation between upper and lower bounds, which helps traders identify potential trading opportunities. The upper and lower bounds are displayed on the graph, making it easier for traders to see when they are crossed(trigger_alert).